### PR TITLE
Use self-hosted-default gha runners

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -88,6 +88,11 @@ on:
         type: boolean
         description: "Wait until ArgoCD successfully apply the changes"
         default: true
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -122,6 +127,7 @@ jobs:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
       tests_enabled: ${{ inputs.tests_enabled }}
+      runs-on: ${{ inputs.runs-on }}
 
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
@@ -152,6 +158,7 @@ jobs:
         qa3: deploy/qa3
         qa4: deploy/qa4
       synchronously: ${{ inputs.synchronously }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}

--- a/.github/workflows/hotfix-branch.yml
+++ b/.github/workflows/hotfix-branch.yml
@@ -88,6 +88,11 @@ on:
         type: boolean
         description: "Wait until ArgoCD successfully apply the changes"
         default: true
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -122,7 +127,7 @@ jobs:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
       tests_enabled: ${{ inputs.tests_enabled }}
-
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -148,6 +153,7 @@ jobs:
       env-label: |
         hotfix: deploy
       synchronously: ${{ inputs.synchronously }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}

--- a/.github/workflows/hotfix-mixin.yml
+++ b/.github/workflows/hotfix-mixin.yml
@@ -43,6 +43,11 @@ on:
         description: "Release version tag"
         required: true
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
 
 permissions:
   id-token: write
@@ -57,3 +62,4 @@ jobs:
     uses: cloudposse/github-action-workflows/.github/workflows/controller-hotfix-release-branch.yml@main
     with:
       version: ${{ inputs.version }}
+      runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -72,6 +72,11 @@ on:
         type: boolean
         description: "Wait until ArgoCD successfully apply the changes"
         default: true
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -104,7 +109,7 @@ jobs:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
       tests_enabled: ${{ inputs.tests_enabled }}
-
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -116,7 +121,7 @@ jobs:
     uses: cloudposse/github-actions-workflows/.github/workflows/controller-hotfix-release.yml@main
     with:
       ref: ${{ github.sha }}
-
+      runs-on: ${{ inputs.runs-on }}
   promote:
     needs: [release]
     uses: cloudposse/github-action-workflows/.github/workflows/ci-dockerized-app-promote.yml@main
@@ -124,6 +129,7 @@ jobs:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
       version: ${{ needs.release.outputs.version }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -144,6 +150,7 @@ jobs:
       toolchain: ${{ inputs.toolchain }}
       values_file: ${{ inputs.values_file }}
       synchronously: ${{ inputs.synchronously }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
@@ -154,6 +161,7 @@ jobs:
     with:
       ref: ${{ github.ref }}
       target_branch: ${{ inputs.default_branch }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
 

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -67,6 +67,11 @@ on:
         type: boolean
         description: "Wait until ArgoCD successfully apply the changes"
         default: true
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -99,7 +104,7 @@ jobs:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
       tests_enabled: ${{ inputs.tests_enabled }}
-
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -119,6 +124,7 @@ jobs:
       toolchain: ${{ inputs.toolchain }}
       values_file: ${{ inputs.values_file }}
       synchronously: ${{ inputs.synchronously }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
@@ -128,3 +134,4 @@ jobs:
     needs: [ cd ]
     secrets:
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
+      runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,11 @@ on:
         type: boolean
         description: "Wait until ArgoCD successfully apply the changes"
         default: true
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -105,6 +110,7 @@ jobs:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
       version: ${{ inputs.version }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -125,6 +131,7 @@ jobs:
       toolchain: ${{ inputs.toolchain }}
       values_file: ${{ inputs.values_file }}
       synchronously: ${{ inputs.synchronously }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
@@ -143,6 +150,7 @@ jobs:
       toolchain: ${{ inputs.toolchain }}
       values_file: ${{ inputs.values_file }}
       synchronously: ${{ inputs.synchronously }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}


### PR DESCRIPTION
## what
* Use `self-hosted-default` gha runners

## references
* DEV-2353 Review workflows in the cloudposse org for specific runs-on settings on self-hosted runners and ensure they have the correct labels and include core-auto
